### PR TITLE
Add Attributes v2 API to the NG Secret Provider

### DIFF
--- a/src/main/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdvice.java
+++ b/src/main/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdvice.java
@@ -3,6 +3,7 @@ package com.otilm.common.credential.provider;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.common.error.ProblemDetailExtended;
+import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
 import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +70,12 @@ public class ProblemDetailsHandlingAdvice extends ResponseEntityExceptionHandler
     public ProblemDetail handleAlreadyExistException(AlreadyExistException ex) {
         LOG.error("Already exist error occurred: {}", ex.getMessage(), ex);
         return ProblemDetailExtended.fromErrorCode(ErrorCode.RESOURCE_ALREADY_EXISTS, ex.getMessage(), null, null);
+    }
+
+    @ExceptionHandler(AttributeDefinitionNotFoundException.class)
+    public ProblemDetail handleAttributeDefinitionNotFound(AttributeDefinitionNotFoundException ex) {
+        LOG.error("Attribute definition not found: {}", ex.getMessage(), ex);
+        return ProblemDetailExtended.fromErrorCode(ErrorCode.ATTRIBUTE_DEFINITION_NOT_FOUND, ex.getMessage(), null, null);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdvice.java
+++ b/src/main/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdvice.java
@@ -3,6 +3,7 @@ package com.otilm.common.credential.provider;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.common.error.ProblemDetailExtended;
+import com.otilm.common.credential.provider.secret.api.v2.AttributeCallbackNotSupportedException;
 import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
 import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
@@ -76,6 +77,12 @@ public class ProblemDetailsHandlingAdvice extends ResponseEntityExceptionHandler
     public ProblemDetail handleAttributeDefinitionNotFound(AttributeDefinitionNotFoundException ex) {
         LOG.error("Attribute definition not found: {}", ex.getMessage(), ex);
         return ProblemDetailExtended.fromErrorCode(ErrorCode.ATTRIBUTE_DEFINITION_NOT_FOUND, ex.getMessage(), null, null);
+    }
+
+    @ExceptionHandler(AttributeCallbackNotSupportedException.class)
+    public ProblemDetail handleAttributeCallbackNotSupported(AttributeCallbackNotSupportedException ex) {
+        LOG.error("Attribute callback not supported: {}", ex.getMessage(), ex);
+        return ProblemDetailExtended.fromErrorCode(ErrorCode.VALIDATION_FAILED, ex.getMessage(), null, null);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/otilm/common/credential/provider/api/v2/InfoControllerImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/api/v2/InfoControllerImpl.java
@@ -46,9 +46,18 @@ public class InfoControllerImpl implements InfoController {
         connectorInterfaceInfoSecret.setVersion("v1");
         connectorInterfaceInfoSecret.setFeatures(List.of(FeatureFlag.STATELESS));
 
+        ConnectorInterfaceInfo connectorInterfaceInfoAttributes = new ConnectorInterfaceInfo();
+        connectorInterfaceInfoAttributes.setCode(ConnectorInterface.ATTRIBUTES);
+        connectorInterfaceInfoAttributes.setVersion("v2");
+
         InfoResponse infoResponse = new InfoResponse();
         infoResponse.setConnector(connectorInfo);
-        infoResponse.setInterfaces(List.of(connectorInterfaceInfo, connectorInterfaceInfoHealth, connectorInterfaceInfoMetrics, connectorInterfaceInfoSecret));
+        infoResponse.setInterfaces(List.of(
+                connectorInterfaceInfo,
+                connectorInterfaceInfoHealth,
+                connectorInterfaceInfoMetrics,
+                connectorInterfaceInfoAttributes,
+                connectorInterfaceInfoSecret));
 
         return infoResponse;
     }

--- a/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeCallbackNotSupportedException.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeCallbackNotSupportedException.java
@@ -1,0 +1,24 @@
+package com.otilm.common.credential.provider.secret.api.v2;
+
+import java.util.UUID;
+
+/**
+ * Thrown by the callback surface when the requested attribute exists in the registry but declares no
+ * callback, so there is nothing to resolve. Distinct from {@link AttributeDefinitionNotFoundException}
+ * (unknown UUID): a registry refresh would never make a non-dispatchable attribute dispatchable, so
+ * this is a non-retryable rejection rather than a not-found. Unchecked because the
+ * {@code AttributesController} interface methods declare no checked exceptions.
+ */
+public class AttributeCallbackNotSupportedException extends RuntimeException {
+
+    private final transient UUID uuid;
+
+    public AttributeCallbackNotSupportedException(UUID uuid) {
+        super("Attribute defines no callback: " + uuid);
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+}

--- a/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeCallbackNotSupportedException.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeCallbackNotSupportedException.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  */
 public class AttributeCallbackNotSupportedException extends RuntimeException {
 
-    private final transient UUID uuid;
+    private final UUID uuid;
 
     public AttributeCallbackNotSupportedException(UUID uuid) {
         super("Attribute defines no callback: " + uuid);

--- a/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeDefinitionNotFoundException.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeDefinitionNotFoundException.java
@@ -1,0 +1,22 @@
+package com.otilm.common.credential.provider.secret.api.v2;
+
+import java.util.UUID;
+
+/**
+ * Thrown when a requested attribute UUID is not a resolvable definition on this connector —
+ * unknown to the registry, or (on the callback surface) present but not callback-dispatchable.
+ * Unchecked because the {@code AttributesController} interface methods declare no checked exceptions.
+ */
+public class AttributeDefinitionNotFoundException extends RuntimeException {
+
+    private final transient UUID uuid;
+
+    public AttributeDefinitionNotFoundException(UUID uuid) {
+        super("Attribute definition not found for UUID: " + uuid);
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+}

--- a/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeDefinitionNotFoundException.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeDefinitionNotFoundException.java
@@ -10,7 +10,7 @@ import java.util.UUID;
  */
 public class AttributeDefinitionNotFoundException extends RuntimeException {
 
-    private final transient UUID uuid;
+    private final UUID uuid;
 
     public AttributeDefinitionNotFoundException(UUID uuid) {
         super("Attribute definition not found for UUID: " + uuid);

--- a/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeDefinitionNotFoundException.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributeDefinitionNotFoundException.java
@@ -3,9 +3,10 @@ package com.otilm.common.credential.provider.secret.api.v2;
 import java.util.UUID;
 
 /**
- * Thrown when a requested attribute UUID is not a resolvable definition on this connector —
- * unknown to the registry, or (on the callback surface) present but not callback-dispatchable.
- * Unchecked because the {@code AttributesController} interface methods declare no checked exceptions.
+ * Thrown when a requested attribute UUID is unknown to this connector's registry (no matching
+ * definition). A known attribute that merely declares no callback is a different case — see
+ * {@link AttributeCallbackNotSupportedException}. Unchecked because the {@code AttributesController}
+ * interface methods declare no checked exceptions.
  */
 public class AttributeDefinitionNotFoundException extends RuntimeException {
 

--- a/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributesControllerImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/api/v2/AttributesControllerImpl.java
@@ -1,0 +1,39 @@
+package com.otilm.common.credential.provider.secret.api.v2;
+
+import com.otilm.api.interfaces.connector.common.v2.AttributesController;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.common.credential.provider.ConnectorV2Api;
+import com.otilm.common.credential.provider.secret.service.SecretProviderAttributesService;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController("attributesControllerV2")
+@ConnectorV2Api
+public class AttributesControllerImpl implements AttributesController {
+
+    private final SecretProviderAttributesService attributesService;
+
+    public AttributesControllerImpl(SecretProviderAttributesService attributesService) {
+        this.attributesService = attributesService;
+    }
+
+    @Override
+    public AttributeDefinitionsDto listDefinitions(List<UUID> uuids) {
+        return attributesService.listDefinitions(uuids);
+    }
+
+    @Override
+    public BaseAttribute getDefinition(UUID uuid) {
+        return attributesService.getDefinition(uuid);
+    }
+
+    @Override
+    public AttributeCallbackResponseDto callback(AttributeCallbackRequestDto request) {
+        return attributesService.callback(request);
+    }
+}

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesService.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesService.java
@@ -1,0 +1,26 @@
+package com.otilm.common.credential.provider.secret.service;
+
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The common Attributes v2 provider for this connector's NG Secret Provider: the UUID-keyed
+ * attribute-definition registry plus the callback surface. The registry aggregates the definitions
+ * the connector's existing attribute owners produce; it does not own or mutate them.
+ */
+public interface SecretProviderAttributesService {
+
+    /** Full registry, or the found-only subset when {@code uuids} is non-empty (unknowns dropped). */
+    AttributeDefinitionsDto listDefinitions(List<UUID> uuids);
+
+    /** A single definition by connector-global UUID; throws when unknown. */
+    BaseAttribute getDefinition(UUID uuid);
+
+    /** Resolve dynamic content for a callback-enabled attribute. This connector declares none. */
+    AttributeCallbackResponseDto callback(AttributeCallbackRequestDto request);
+}

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/VaultAttributeService.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/VaultAttributeService.java
@@ -14,5 +14,12 @@ public interface VaultAttributeService {
 
     List<BaseAttribute> listVaultAttributes();
 
+    /**
+     * The vault attribute definitions as pure shape — no resolved option content, so no DB read.
+     * The Attributes v2 registry uses this; {@link #listVaultAttributes()} is the form-rendering
+     * path that additionally populates dynamic option content.
+     */
+    List<BaseAttribute> listVaultAttributeDefinitions();
+
     List<BaseAttribute> listVaultProfileAttributes();
 }

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -30,8 +30,8 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
 
     /**
      * Startup self-validation: fail fast if the connector-global registry contains a
-     * duplicate UUID. The "every {@code dependsOn} attribute is dispatchable" half is vacuously
-     * satisfied — this connector declares no callbacks — but the check guards future additions.
+     * duplicate UUID. This connector declares no callbacks, so there is no callback-dispatchability
+     * check here yet — add one alongside the first attribute that declares a callback.
      */
     @PostConstruct
     void validateRegistry() {

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -29,7 +29,7 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     }
 
     /**
-     * Startup self-validation (umbrella D18): fail fast if the connector-global registry contains a
+     * Startup self-validation: fail fast if the connector-global registry contains a
      * duplicate UUID. The "every {@code dependsOn} attribute is dispatchable" half is vacuously
      * satisfied — this connector declares no callbacks — but the check guards future additions.
      */

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -51,7 +51,7 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
      * owner returns them.
      */
     private List<BaseAttribute> allDefinitions() {
-        return vaultAttributeService.listVaultAttributes();
+        return vaultAttributeService.listVaultAttributeDefinitions();
     }
 
     @Override

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -32,7 +32,7 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     /**
      * Startup self-validation: fail fast if the connector-global registry contains a malformed or
      * duplicate UUID. This connector declares no callbacks, so there is no callback-dispatchability
-     * check here yet — add one alongside the first attribute that declares a callback.
+     * check here yet.
      */
     @PostConstruct
     void validateRegistry() {
@@ -50,10 +50,11 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     }
 
     /**
-     * Every NG attribute definition this connector exposes. Only vault-instance attributes are
-     * non-empty today; the other NG sources (vault-profile, per-secret-type, rotate) return empty,
-     * so aggregating {@code listVaultAttributeDefinitions()} is complete. New attributes appear here
-     * once their owner returns them.
+     * Every NG attribute definition this connector exposes. Today that is only the vault-instance
+     * attributes: the other NG sources (vault-profile, per-secret-type, rotate) return empty — pinned
+     * by their own tests — so aggregating {@code listVaultAttributeDefinitions()} is complete. If any
+     * of those sources ever becomes non-empty it must be wired in here too, or it will be absent from
+     * the registry.
      */
     private List<BaseAttribute> allDefinitions() {
         return vaultAttributeService.listVaultAttributeDefinitions();

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -1,0 +1,88 @@
+package com.otilm.common.credential.provider.secret.service.impl;
+
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
+import com.otilm.common.credential.provider.secret.service.SecretProviderAttributesService;
+import com.otilm.common.credential.provider.secret.service.VaultAttributeService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class SecretProviderAttributesServiceImpl implements SecretProviderAttributesService {
+
+    private final BuildProperties buildProperties;
+    private final VaultAttributeService vaultAttributeService;
+
+    public SecretProviderAttributesServiceImpl(BuildProperties buildProperties,
+                                               VaultAttributeService vaultAttributeService) {
+        this.buildProperties = buildProperties;
+        this.vaultAttributeService = vaultAttributeService;
+    }
+
+    /**
+     * Startup self-validation (umbrella D18): fail fast if the connector-global registry contains a
+     * duplicate UUID. The "every {@code dependsOn} attribute is dispatchable" half is vacuously
+     * satisfied — this connector declares no callbacks — but the check guards future additions.
+     */
+    @PostConstruct
+    void validateRegistry() {
+        Set<String> seen = new HashSet<>();
+        for (BaseAttribute definition : allDefinitions()) {
+            if (!seen.add(definition.getUuid())) {
+                throw new IllegalStateException(
+                        "Duplicate attribute UUID in connector registry: " + definition.getUuid());
+            }
+        }
+    }
+
+    /**
+     * Every NG attribute definition this connector exposes. Only vault-instance attributes are
+     * non-empty today; the other NG sources (vault-profile, per-secret-type, rotate) return empty,
+     * so aggregating {@code listVaultAttributes()} is complete. New attributes appear here once their
+     * owner returns them.
+     */
+    private List<BaseAttribute> allDefinitions() {
+        return vaultAttributeService.listVaultAttributes();
+    }
+
+    @Override
+    public AttributeDefinitionsDto listDefinitions(List<UUID> uuids) {
+        List<BaseAttribute> definitions = allDefinitions();
+        if (uuids != null && !uuids.isEmpty()) {
+            Set<String> wanted = new HashSet<>();
+            uuids.forEach(uuid -> wanted.add(uuid.toString()));
+            definitions = definitions.stream()
+                    .filter(definition -> wanted.contains(definition.getUuid()))
+                    .toList();
+        }
+        AttributeDefinitionsDto dto = new AttributeDefinitionsDto();
+        dto.setConnectorVersion(buildProperties.getVersion());
+        dto.setDefinitions(definitions);
+        return dto;
+    }
+
+    @Override
+    public BaseAttribute getDefinition(UUID uuid) {
+        String key = uuid.toString();
+        return allDefinitions().stream()
+                .filter(definition -> key.equals(definition.getUuid()))
+                .findFirst()
+                .orElseThrow(() -> new AttributeDefinitionNotFoundException(uuid));
+    }
+
+    @Override
+    public AttributeCallbackResponseDto callback(AttributeCallbackRequestDto request) {
+        // No attribute declares an NG callback (dependsOn), so nothing is dispatchable. In normal
+        // operation Core never calls this — it only dispatches for attributes advertising dependsOn.
+        throw new AttributeDefinitionNotFoundException(request.getAttributeUuid());
+    }
+}

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -4,6 +4,7 @@ import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackReques
 import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
 import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.common.credential.provider.secret.api.v2.AttributeCallbackNotSupportedException;
 import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
 import com.otilm.common.credential.provider.secret.service.SecretProviderAttributesService;
 import com.otilm.common.credential.provider.secret.service.VaultAttributeService;
@@ -47,8 +48,8 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     /**
      * Every NG attribute definition this connector exposes. Only vault-instance attributes are
      * non-empty today; the other NG sources (vault-profile, per-secret-type, rotate) return empty,
-     * so aggregating {@code listVaultAttributes()} is complete. New attributes appear here once their
-     * owner returns them.
+     * so aggregating {@code listVaultAttributeDefinitions()} is complete. New attributes appear here
+     * once their owner returns them.
      */
     private List<BaseAttribute> allDefinitions() {
         return vaultAttributeService.listVaultAttributeDefinitions();
@@ -81,8 +82,17 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
 
     @Override
     public AttributeCallbackResponseDto callback(AttributeCallbackRequestDto request) {
-        // No attribute declares an NG callback (dependsOn), so nothing is dispatchable. In normal
-        // operation Core never calls this — it only dispatches for attributes advertising dependsOn.
-        throw new AttributeDefinitionNotFoundException(request.getAttributeUuid());
+        UUID uuid = request.getAttributeUuid();
+        String key = uuid.toString();
+        boolean known = allDefinitions().stream()
+                .anyMatch(definition -> key.equals(definition.getUuid()));
+        if (!known) {
+            // Unknown to this connector — 404; Core refreshing its registry is a sensible reaction.
+            throw new AttributeDefinitionNotFoundException(uuid);
+        }
+        // Known, but this connector declares no NG callback (dependsOn), so nothing is dispatchable;
+        // a registry refresh would not change that, so reject as non-retryable rather than not-found.
+        // In normal operation Core never calls this — it only dispatches attributes advertising dependsOn.
+        throw new AttributeCallbackNotSupportedException(uuid);
     }
 }

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/SecretProviderAttributesServiceImpl.java
@@ -30,17 +30,21 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     }
 
     /**
-     * Startup self-validation: fail fast if the connector-global registry contains a
+     * Startup self-validation: fail fast if the connector-global registry contains a malformed or
      * duplicate UUID. This connector declares no callbacks, so there is no callback-dispatchability
      * check here yet — add one alongside the first attribute that declares a callback.
      */
     @PostConstruct
     void validateRegistry() {
-        Set<String> seen = new HashSet<>();
+        Set<UUID> seen = new HashSet<>();
         for (BaseAttribute definition : allDefinitions()) {
-            if (!seen.add(definition.getUuid())) {
+            UUID uuid = definitionUuid(definition);
+            if (uuid == null) {
                 throw new IllegalStateException(
-                        "Duplicate attribute UUID in connector registry: " + definition.getUuid());
+                        "Attribute UUID is not a valid UUID: " + definition.getUuid());
+            }
+            if (!seen.add(uuid)) {
+                throw new IllegalStateException("Duplicate attribute UUID in connector registry: " + uuid);
             }
         }
     }
@@ -59,10 +63,9 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     public AttributeDefinitionsDto listDefinitions(List<UUID> uuids) {
         List<BaseAttribute> definitions = allDefinitions();
         if (uuids != null && !uuids.isEmpty()) {
-            Set<String> wanted = new HashSet<>();
-            uuids.forEach(uuid -> wanted.add(uuid.toString()));
+            Set<UUID> wanted = new HashSet<>(uuids);
             definitions = definitions.stream()
-                    .filter(definition -> wanted.contains(definition.getUuid()))
+                    .filter(definition -> wanted.contains(definitionUuid(definition)))
                     .toList();
         }
         AttributeDefinitionsDto dto = new AttributeDefinitionsDto();
@@ -73,9 +76,8 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
 
     @Override
     public BaseAttribute getDefinition(UUID uuid) {
-        String key = uuid.toString();
         return allDefinitions().stream()
-                .filter(definition -> key.equals(definition.getUuid()))
+                .filter(definition -> uuid.equals(definitionUuid(definition)))
                 .findFirst()
                 .orElseThrow(() -> new AttributeDefinitionNotFoundException(uuid));
     }
@@ -83,16 +85,32 @@ public class SecretProviderAttributesServiceImpl implements SecretProviderAttrib
     @Override
     public AttributeCallbackResponseDto callback(AttributeCallbackRequestDto request) {
         UUID uuid = request.getAttributeUuid();
-        String key = uuid.toString();
         boolean known = allDefinitions().stream()
-                .anyMatch(definition -> key.equals(definition.getUuid()));
+                .anyMatch(definition -> uuid.equals(definitionUuid(definition)));
         if (!known) {
             // Unknown to this connector — 404; Core refreshing its registry is a sensible reaction.
             throw new AttributeDefinitionNotFoundException(uuid);
         }
-        // Known, but this connector declares no NG callback (dependsOn), so nothing is dispatchable;
-        // a registry refresh would not change that, so reject as non-retryable rather than not-found.
-        // In normal operation Core never calls this — it only dispatches attributes advertising dependsOn.
+        // The attribute is known but declares no NG callback, so nothing can be resolved. A registry
+        // refresh would not change that, so this is a non-retryable rejection rather than a not-found.
+        // Core does not reach here in normal operation — it dispatches only callback-enabled attributes.
         throw new AttributeCallbackNotSupportedException(uuid);
+    }
+
+    /**
+     * The attribute's identifier as a {@link UUID}, or {@code null} if it is absent or not a valid
+     * UUID. Matching by value keeps lookups correct regardless of the identifier's textual form;
+     * {@link #validateRegistry()} rejects a malformed identifier at startup.
+     */
+    private static UUID definitionUuid(BaseAttribute definition) {
+        String raw = definition.getUuid();
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return UUID.fromString(raw);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/otilm/common/credential/provider/secret/service/impl/VaultAttributeServiceImpl.java
+++ b/src/main/java/com/otilm/common/credential/provider/secret/service/impl/VaultAttributeServiceImpl.java
@@ -27,7 +27,18 @@ public class VaultAttributeServiceImpl implements VaultAttributeService {
 
     @Override
     public List<BaseAttribute> listVaultAttributes() {
-        return List.of(namespaceAttribute());
+        DataAttributeV3 namespace = namespaceDefinition();
+        // Offer the namespaces already in use as options; extensibleList lets the operator type a new one.
+        List<StringAttributeContentV3> existing = secretRepository.findDistinctNamespaces().stream()
+                .map(StringAttributeContentV3::new)
+                .toList();
+        namespace.setContent(existing);
+        return List.of(namespace);
+    }
+
+    @Override
+    public List<BaseAttribute> listVaultAttributeDefinitions() {
+        return List.of(namespaceDefinition());
     }
 
     @Override
@@ -35,19 +46,13 @@ public class VaultAttributeServiceImpl implements VaultAttributeService {
         return List.of();
     }
 
-    private BaseAttribute namespaceAttribute() {
+    private DataAttributeV3 namespaceDefinition() {
         DataAttributeV3 namespace = new DataAttributeV3();
         namespace.setUuid(ATTRIBUTE_NAMESPACE_UUID);
         namespace.setName(ATTRIBUTE_NAMESPACE);
         namespace.setDescription("Optional namespace used to group and scope secrets within this vault");
         namespace.setType(AttributeType.DATA);
         namespace.setContentType(AttributeContentType.STRING);
-
-        // Offer the namespaces already in use as options; extensibleList lets the operator type a new one.
-        List<StringAttributeContentV3> existing = secretRepository.findDistinctNamespaces().stream()
-                .map(StringAttributeContentV3::new)
-                .toList();
-        namespace.setContent(existing);
 
         DataAttributeProperties properties = new DataAttributeProperties();
         properties.setLabel(ATTRIBUTE_NAMESPACE_LABEL);

--- a/src/test/java/com/otilm/common/credential/provider/LoggingAdviceCoverageTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/LoggingAdviceCoverageTest.java
@@ -28,7 +28,7 @@ class LoggingAdviceCoverageTest {
     private AttributesController attributesController;
 
     @Test
-    void secretAndVaultControllersAreAdvisedByLoggingAdvice() {
+    void ngControllersAreAdvisedByLoggingAdvice() {
         Assertions.assertTrue(AopUtils.isAopProxy(secretController),
                 "SecretController must be advised by LoggingAdvice");
         Assertions.assertTrue(AopUtils.isAopProxy(vaultController),

--- a/src/test/java/com/otilm/common/credential/provider/LoggingAdviceCoverageTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/LoggingAdviceCoverageTest.java
@@ -1,5 +1,6 @@
 package com.otilm.common.credential.provider;
 
+import com.otilm.api.interfaces.connector.common.v2.AttributesController;
 import com.otilm.api.interfaces.connector.secrets.SecretController;
 import com.otilm.api.interfaces.connector.secrets.VaultController;
 import org.junit.jupiter.api.Assertions;
@@ -23,11 +24,16 @@ class LoggingAdviceCoverageTest {
     @Autowired
     private VaultController vaultController;
 
+    @Autowired
+    private AttributesController attributesController;
+
     @Test
     void secretAndVaultControllersAreAdvisedByLoggingAdvice() {
         Assertions.assertTrue(AopUtils.isAopProxy(secretController),
                 "SecretController must be advised by LoggingAdvice");
         Assertions.assertTrue(AopUtils.isAopProxy(vaultController),
                 "VaultController must be advised by LoggingAdvice");
+        Assertions.assertTrue(AopUtils.isAopProxy(attributesController),
+                "AttributesController must be advised by LoggingAdvice");
     }
 }

--- a/src/test/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdviceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdviceTest.java
@@ -1,0 +1,26 @@
+package com.otilm.common.credential.provider;
+
+import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProblemDetailsHandlingAdviceTest {
+
+    private final ProblemDetailsHandlingAdvice advice = new ProblemDetailsHandlingAdvice();
+
+    @Test
+    void attributeDefinitionNotFoundMapsTo404WithAttributeErrorCode() {
+        UUID uuid = UUID.randomUUID();
+        ProblemDetail problem = advice.handleAttributeDefinitionNotFound(
+                new AttributeDefinitionNotFoundException(uuid));
+
+        assertEquals(404, problem.getStatus());
+        assertTrue(problem.getType().toString().endsWith("ATTRIBUTE_DEFINITION_NOT_FOUND"),
+                "type must carry the ATTRIBUTE_DEFINITION_NOT_FOUND code, was " + problem.getType());
+    }
+}

--- a/src/test/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdviceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/ProblemDetailsHandlingAdviceTest.java
@@ -1,5 +1,6 @@
 package com.otilm.common.credential.provider;
 
+import com.otilm.common.credential.provider.secret.api.v2.AttributeCallbackNotSupportedException;
 import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ProblemDetail;
@@ -22,5 +23,15 @@ class ProblemDetailsHandlingAdviceTest {
         assertEquals(404, problem.getStatus());
         assertTrue(problem.getType().toString().endsWith("ATTRIBUTE_DEFINITION_NOT_FOUND"),
                 "type must carry the ATTRIBUTE_DEFINITION_NOT_FOUND code, was " + problem.getType());
+    }
+
+    @Test
+    void attributeCallbackNotSupportedMapsTo422WithValidationCode() {
+        ProblemDetail problem = advice.handleAttributeCallbackNotSupported(
+                new AttributeCallbackNotSupportedException(UUID.randomUUID()));
+
+        assertEquals(422, problem.getStatus());
+        assertTrue(problem.getType().toString().endsWith("VALIDATION_FAILED"),
+                "type must carry the VALIDATION_FAILED code, was " + problem.getType());
     }
 }

--- a/src/test/java/com/otilm/common/credential/provider/api/v2/InfoControllerTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/api/v2/InfoControllerTest.java
@@ -29,4 +29,13 @@ class InfoControllerTest {
         assertNotNull(response.getConnector());
         assertEquals("com.otilm.common.credential.provider", response.getConnector().getId());
     }
+
+    @Test
+    void testGetConnectorInfo_AdvertisesAttributesV2() {
+        InfoResponse response = infoController.getConnectorInfo();
+
+        boolean advertisesAttributesV2 = response.getInterfaces().stream()
+                .anyMatch(i -> i.getCode() == ConnectorInterface.ATTRIBUTES && "v2".equals(i.getVersion()));
+        assertTrue(advertisesAttributesV2, "connector must advertise ATTRIBUTES at version v2");
+    }
 }

--- a/src/test/java/com/otilm/common/credential/provider/secret/api/v2/AttributesControllerImplTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/api/v2/AttributesControllerImplTest.java
@@ -1,5 +1,7 @@
 package com.otilm.common.credential.provider.secret.api.v2;
 
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
 import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.common.credential.provider.secret.service.SecretProviderAttributesService;
@@ -34,5 +36,15 @@ class AttributesControllerImplTest {
 
         assertSame(def, controller.getDefinition(uuid));
         verify(service).getDefinition(uuid);
+    }
+
+    @Test
+    void callbackDelegatesToService() {
+        AttributeCallbackRequestDto request = new AttributeCallbackRequestDto();
+        AttributeCallbackResponseDto response = new AttributeCallbackResponseDto();
+        when(service.callback(request)).thenReturn(response);
+
+        assertSame(response, controller.callback(request));
+        verify(service).callback(request);
     }
 }

--- a/src/test/java/com/otilm/common/credential/provider/secret/api/v2/AttributesControllerImplTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/api/v2/AttributesControllerImplTest.java
@@ -1,0 +1,38 @@
+package com.otilm.common.credential.provider.secret.api.v2;
+
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.common.credential.provider.secret.service.SecretProviderAttributesService;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AttributesControllerImplTest {
+
+    private final SecretProviderAttributesService service = mock(SecretProviderAttributesService.class);
+    private final AttributesControllerImpl controller = new AttributesControllerImpl(service);
+
+    @Test
+    void listDefinitionsDelegatesToService() {
+        AttributeDefinitionsDto dto = new AttributeDefinitionsDto();
+        when(service.listDefinitions(isNull())).thenReturn(dto);
+
+        assertSame(dto, controller.listDefinitions(null));
+    }
+
+    @Test
+    void getDefinitionDelegatesToService() {
+        UUID uuid = UUID.randomUUID();
+        BaseAttribute def = mock(BaseAttribute.class);
+        when(service.getDefinition(uuid)).thenReturn(def);
+
+        assertSame(def, controller.getDefinition(uuid));
+        verify(service).getDefinition(uuid);
+    }
+}

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
@@ -1,0 +1,82 @@
+package com.otilm.common.credential.provider.secret.service;
+
+import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
+import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
+import com.otilm.common.credential.provider.secret.service.impl.SecretProviderAttributesServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.info.BuildProperties;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SecretProviderAttributesServiceTest {
+
+    private static final UUID KNOWN = UUID.fromString("d18a014f-cfb9-4e72-8acc-4616e14fe8ad");
+
+    private final VaultAttributeService vaultAttributeService = mock(VaultAttributeService.class);
+    private SecretProviderAttributesServiceImpl service;
+    private DataAttributeV3 namespaceDef;
+
+    @BeforeEach
+    void setup() {
+        namespaceDef = new DataAttributeV3();
+        namespaceDef.setUuid(KNOWN.toString());
+        namespaceDef.setName("data_namespace");
+        namespaceDef.setType(AttributeType.DATA);
+        namespaceDef.setContentType(AttributeContentType.STRING);
+        when(vaultAttributeService.listVaultAttributes()).thenReturn(List.of(namespaceDef));
+
+        Properties props = new Properties();
+        props.setProperty("version", "1.2.3");
+        service = new SecretProviderAttributesServiceImpl(new BuildProperties(props), vaultAttributeService);
+    }
+
+    @Test
+    void listDefinitionsWithoutFilterReturnsFullRegistryAndConnectorVersion() {
+        AttributeDefinitionsDto dto = service.listDefinitions(null);
+        assertEquals("1.2.3", dto.getConnectorVersion());
+        assertEquals(1, dto.getDefinitions().size());
+        assertSame(namespaceDef, dto.getDefinitions().get(0));
+    }
+
+    @Test
+    void listDefinitionsFilterKeepsKnownDropsUnknown() {
+        AttributeDefinitionsDto known = service.listDefinitions(List.of(KNOWN));
+        assertEquals(1, known.getDefinitions().size());
+
+        AttributeDefinitionsDto unknown = service.listDefinitions(List.of(UUID.randomUUID()));
+        assertTrue(unknown.getDefinitions().isEmpty());
+    }
+
+    @Test
+    void getDefinitionReturnsSameObjectForKnownUuid() {
+        assertSame(namespaceDef, service.getDefinition(KNOWN));
+    }
+
+    @Test
+    void getDefinitionThrowsForUnknownUuid() {
+        assertThrows(AttributeDefinitionNotFoundException.class,
+                () -> service.getDefinition(UUID.randomUUID()));
+    }
+
+    @Test
+    void callbackAlwaysThrowsBecauseNoAttributeIsDispatchable() {
+        AttributeCallbackRequestDto req = new AttributeCallbackRequestDto();
+        req.setAttributeUuid(KNOWN);
+        assertThrows(AttributeDefinitionNotFoundException.class, () -> service.callback(req));
+    }
+}

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
@@ -6,6 +6,7 @@ import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.common.credential.provider.secret.api.v2.AttributeCallbackNotSupportedException;
 import com.otilm.common.credential.provider.secret.api.v2.AttributeDefinitionNotFoundException;
 import com.otilm.common.credential.provider.secret.service.impl.SecretProviderAttributesServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,9 +76,16 @@ class SecretProviderAttributesServiceTest {
     }
 
     @Test
-    void callbackAlwaysThrowsBecauseNoAttributeIsDispatchable() {
+    void callbackForKnownButNonDispatchableAttributeThrowsNotSupported() {
         AttributeCallbackRequestDto req = new AttributeCallbackRequestDto();
         req.setAttributeUuid(KNOWN);
+        assertThrows(AttributeCallbackNotSupportedException.class, () -> service.callback(req));
+    }
+
+    @Test
+    void callbackForUnknownAttributeThrowsNotFound() {
+        AttributeCallbackRequestDto req = new AttributeCallbackRequestDto();
+        req.setAttributeUuid(UUID.randomUUID());
         assertThrows(AttributeDefinitionNotFoundException.class, () -> service.callback(req));
     }
 

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
@@ -3,7 +3,6 @@ package com.otilm.common.credential.provider.secret.service;
 import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
 import com.otilm.api.model.client.connector.v2.attribute.AttributeDefinitionsDto;
 import com.otilm.api.model.common.attribute.common.AttributeType;
-import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.common.credential.provider.secret.api.v2.AttributeCallbackNotSupportedException;
@@ -60,8 +59,9 @@ class SecretProviderAttributesServiceTest {
         AttributeDefinitionsDto known = service.listDefinitions(List.of(KNOWN));
         assertEquals(1, known.getDefinitions().size());
 
-        AttributeDefinitionsDto unknown = service.listDefinitions(List.of(UUID.randomUUID()));
-        assertTrue(unknown.getDefinitions().isEmpty());
+        UUID unknown = UUID.randomUUID();
+        AttributeDefinitionsDto missing = service.listDefinitions(List.of(unknown));
+        assertTrue(missing.getDefinitions().isEmpty());
     }
 
     @Test
@@ -70,9 +70,19 @@ class SecretProviderAttributesServiceTest {
     }
 
     @Test
+    void getDefinitionMatchesRegardlessOfUuidStringCasing() {
+        DataAttributeV3 upperCaseUuid = new DataAttributeV3();
+        upperCaseUuid.setUuid(KNOWN.toString().toUpperCase());
+        upperCaseUuid.setName("data_namespace");
+        when(vaultAttributeService.listVaultAttributeDefinitions()).thenReturn(List.of(upperCaseUuid));
+
+        assertSame(upperCaseUuid, service.getDefinition(KNOWN));
+    }
+
+    @Test
     void getDefinitionThrowsForUnknownUuid() {
-        assertThrows(AttributeDefinitionNotFoundException.class,
-                () -> service.getDefinition(UUID.randomUUID()));
+        UUID unknown = UUID.randomUUID();
+        assertThrows(AttributeDefinitionNotFoundException.class, () -> service.getDefinition(unknown));
     }
 
     @Test
@@ -84,8 +94,9 @@ class SecretProviderAttributesServiceTest {
 
     @Test
     void callbackForUnknownAttributeThrowsNotFound() {
+        UUID unknown = UUID.randomUUID();
         AttributeCallbackRequestDto req = new AttributeCallbackRequestDto();
-        req.setAttributeUuid(UUID.randomUUID());
+        req.setAttributeUuid(unknown);
         assertThrows(AttributeDefinitionNotFoundException.class, () -> service.callback(req));
     }
 

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
@@ -39,7 +39,7 @@ class SecretProviderAttributesServiceTest {
         namespaceDef.setName("data_namespace");
         namespaceDef.setType(AttributeType.DATA);
         namespaceDef.setContentType(AttributeContentType.STRING);
-        when(vaultAttributeService.listVaultAttributes()).thenReturn(List.of(namespaceDef));
+        when(vaultAttributeService.listVaultAttributeDefinitions()).thenReturn(List.of(namespaceDef));
 
         Properties props = new Properties();
         props.setProperty("version", "1.2.3");
@@ -86,7 +86,7 @@ class SecretProviderAttributesServiceTest {
         DataAttributeV3 duplicate = new DataAttributeV3();
         duplicate.setUuid(KNOWN.toString());
         duplicate.setName("data_namespace_duplicate");
-        when(vaultAttributeService.listVaultAttributes()).thenReturn(List.of(namespaceDef, duplicate));
+        when(vaultAttributeService.listVaultAttributeDefinitions()).thenReturn(List.of(namespaceDef, duplicate));
 
         assertThrows(IllegalStateException.class,
                 () -> ReflectionTestUtils.invokeMethod(service, "validateRegistry"));

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/SecretProviderAttributesServiceTest.java
@@ -11,6 +11,7 @@ import com.otilm.common.credential.provider.secret.service.impl.SecretProviderAt
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.info.BuildProperties;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Properties;
@@ -78,5 +79,21 @@ class SecretProviderAttributesServiceTest {
         AttributeCallbackRequestDto req = new AttributeCallbackRequestDto();
         req.setAttributeUuid(KNOWN);
         assertThrows(AttributeDefinitionNotFoundException.class, () -> service.callback(req));
+    }
+
+    @Test
+    void validateRegistryFailsFastOnDuplicateUuids() {
+        DataAttributeV3 duplicate = new DataAttributeV3();
+        duplicate.setUuid(KNOWN.toString());
+        duplicate.setName("data_namespace_duplicate");
+        when(vaultAttributeService.listVaultAttributes()).thenReturn(List.of(namespaceDef, duplicate));
+
+        assertThrows(IllegalStateException.class,
+                () -> ReflectionTestUtils.invokeMethod(service, "validateRegistry"));
+    }
+
+    @Test
+    void listDefinitionsWithEmptyListReturnsFullRegistry() {
+        assertEquals(1, service.listDefinitions(List.of()).getDefinitions().size());
     }
 }

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/VaultAttributeServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/VaultAttributeServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class VaultAttributeServiceTest {
@@ -60,6 +61,6 @@ class VaultAttributeServiceTest {
         Assertions.assertEquals(VaultAttributeServiceImpl.ATTRIBUTE_NAMESPACE, namespace.getName());
         Assertions.assertTrue(namespace.getProperties().isExtensibleList());
         Assertions.assertNull(namespace.getContent(), "registry definition carries no resolved option content");
-        org.mockito.Mockito.verifyNoInteractions(secretRepository);
+        verifyNoInteractions(secretRepository);
     }
 }

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/VaultAttributeServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/VaultAttributeServiceTest.java
@@ -43,4 +43,12 @@ class VaultAttributeServiceTest {
     void listVaultProfileAttributes_isEmpty() {
         Assertions.assertEquals(List.of(), vaultAttributeService.listVaultProfileAttributes());
     }
+
+    @Test
+    void namespaceAttributeDeclaresNoCallback() {
+        DataAttributeV3 namespace =
+                (DataAttributeV3) vaultAttributeService.listVaultAttributes().get(0);
+        Assertions.assertNull(namespace.getAttributeCallback(),
+                "data_namespace must declare no callback — options are baked extensible-list content");
+    }
 }

--- a/src/test/java/com/otilm/common/credential/provider/secret/service/VaultAttributeServiceTest.java
+++ b/src/test/java/com/otilm/common/credential/provider/secret/service/VaultAttributeServiceTest.java
@@ -51,4 +51,15 @@ class VaultAttributeServiceTest {
         Assertions.assertNull(namespace.getAttributeCallback(),
                 "data_namespace must declare no callback — options are baked extensible-list content");
     }
+
+    @Test
+    void listVaultAttributeDefinitions_hasNoResolvedContentAndDoesNotQueryNamespaces() {
+        DataAttributeV3 namespace =
+                (DataAttributeV3) vaultAttributeService.listVaultAttributeDefinitions().get(0);
+
+        Assertions.assertEquals(VaultAttributeServiceImpl.ATTRIBUTE_NAMESPACE, namespace.getName());
+        Assertions.assertTrue(namespace.getProperties().isExtensibleList());
+        Assertions.assertNull(namespace.getContent(), "registry definition carries no resolved option content");
+        org.mockito.Mockito.verifyNoInteractions(secretRepository);
+    }
 }


### PR DESCRIPTION
Implements the common Attributes v2 provider interface (`com.otilm.api.interfaces.connector.common.v2.AttributesController`, `/v2/attributes`) for the NG Secret Provider. The v1 Credential Provider is unchanged.

Closes #84.

## What changed
- **`AttributesControllerImpl`** (`/v2/attributes`, bean `attributesControllerV2`) implementing the common interface — `listDefinitions`, `getDefinition`, `callback`.
- **`SecretProviderAttributesService`** — the connector-global attribute-definition registry. Aggregates the connector's NG definition shapes (today just `data_namespace`) and self-validates UUID uniqueness at startup.
- **`/v2/info`** now advertises the `ATTRIBUTES` interface at version `v2`.
- **Error mapping** — `ATTRIBUTE_DEFINITION_NOT_FOUND` (404) and, on the callback surface, `VALIDATION_FAILED` (422) via `ProblemDetailsHandlingAdvice`.

## Design notes
- `data_namespace` declares **no callback**: one definition shape, identical on every endpoint (definition-identity). The registry serves the **content-free shape** (no DB read); the existing `VaultController.listVaultAttributes()` form path still returns the shape plus the live namespace options.
- The callback endpoint is **inert** (this connector declares no `dependsOn` callbacks): an unknown UUID returns 404 `ATTRIBUTE_DEFINITION_NOT_FOUND`; a known-but-non-dispatchable UUID returns 422 `VALIDATION_FAILED` (non-retryable, since a registry refresh would never make it dispatchable).

## Acceptance criteria
- [x] NG Secret Provider implements `connector.common.v2.AttributesController`.
- [x] `GET /v2/attributes` returns the attribute-definition registry.
- [x] `GET /v2/attributes/{uuid}` returns a single definition, or `ATTRIBUTE_DEFINITION_NOT_FOUND` when absent.
- [x] `POST /v2/attributes/callback` handles the stateless callback request/response envelope.
- [x] NG connector OpenAPI matches the `doc-openapi-connector-secret-provider` contract — satisfied by implementing the annotated interface (the spec is generated centrally in interface-documentation, where #216 added the controller to that group).
- [x] v1 Credential Provider behaviour unchanged.

## Tests
Full suite green (114/114). Unit coverage for the registry (list / get / filter / duplicate-UUID self-validation), the inert-callback 404-vs-422 split, the content-free / no-DB contract, controller delegation, the error-code mappings, and info advertisement; the context test confirms the controller is wired and advised.

## Follow-ups (not in this PR)
- End-to-end MockMvc web-slice test — the repo has no MockMvc harness today (error mapping is unit-tested, wiring is context-tested).
- The Connector-NG "Attributes" concept docs still describe the old per-operation pattern (documentation repo — org-wide, tied to the interfaces Attributes v2 rollout).
